### PR TITLE
Fix/theme bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ theme = "hugo-noir"
 
 ## Configuration ⚙️
 
-This theme supports a variety of configuration options in your `hugo.toml` (or `config.toml`) file. Below is an example configuration with explanations:
+This theme supports a variety of configuration options in your `hugo.toml` (or `config.toml`) file. An example `hugo.toml` configuration can be found in `exampleSite/hugo.toml`. Below is an example configuration with explanations:
 
 ### Basic Configuration
 

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -1,7 +1,7 @@
 baseURL = "https://johndoe.dev"
 languageCode = 'en-us'
 title = 'John Doe'
-theme = 'doe-minimalistic'
+theme = 'hugo-noir'
 
 # URL handling
 relativeURLs = true


### PR DESCRIPTION
Moved the example config (hugo.yaml) into an 'exampleSite' directory, mirroring it from other hugo themes and changed the theme parameter inside to 'hugo-noir'. 

Fixes the following:
- Error regarding missing theme when adding this theme as either a sub-module or a git clone.

Supplies the following:
- Moved the example configuration with correct theme name
- Updated README.md file.